### PR TITLE
INTERLOK-2840 - Made accessToken/tokenSecret optional

### DIFF
--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/ApacheRfc5849Authenticator.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/ApacheRfc5849Authenticator.java
@@ -43,6 +43,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * {@link ApacheRequestAuthenticator} implementation for you to add as the
  * {@link HttpRequestService#setAuthenticator(HttpAuthenticator)} or similar.
  * </p>
+ * <p>
+ * Note that since this will not have access to payload; this particular implementation does not
+ * support the using the payload as part of the signature base string when the {@code Content-Type}
+ * is {@code application/x-www-form-urlencoded}. If that is the case then use a
+ * {@link GenerateRfc5849Header} with a metadata filter to pre-build an authorisation header.
+ * </p>
  * 
  * @config oauth-apache-http-rfc5849-authenticator
  */

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/AuthorizationData.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/AuthorizationData.java
@@ -132,10 +132,8 @@ public class AuthorizationData {
   @NotBlank
   private String consumerSecret;
   @InputFieldHint(expression = true)
-  @NotBlank
   private String accessToken;
   @InputFieldHint(expression = true, external = true, style = "PASSWORD")
-  @NotBlank
   private String tokenSecret;
   @InputFieldHint(expression = true,
   style = "com.adaptris.core.oauth.rfc5849.AuthorizationData.SignatureMethod")
@@ -143,6 +141,7 @@ public class AuthorizationData {
   private String signatureMethod;
   @InputFieldHint(expression = true)
   @AdvancedConfig
+  @InputFieldDefault(value = "generated from the message unique-id")
   private String nonce;
   @InputFieldHint(expression = true)
   @AdvancedConfig

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/GenerateRfc5849Header.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/GenerateRfc5849Header.java
@@ -51,8 +51,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * {@link ApacheRequestAuthenticator} but since generation of the header does not rely on external
  * connectivity, we can generate the header offline and store it as metadata.
  * </p>
+ * <p>
+ * If the payload is going to be {@code application/x-www-url-form-encoded} then the request body
+ * also needs to be included in the signature base string. You would specify a filter that gives you
+ * the parameters; and subsequently use a
+ * {@link com.adaptris.core.services.metadata.FormDataFromMetadata} to generate the payload.
+ * </p>
  *
  * @config oauth-rfc5849-header-service
+ * @see com.adaptris.core.services.metadata.FormDataFromMetadata
  */
 @XStreamAlias("oauth-rfc5849-header-service")
 @ComponentProfile(
@@ -181,6 +188,17 @@ public class GenerateRfc5849Header extends ServiceImp {
     return additionalData;
   }
 
+  /**
+   * Set any additional data that needs to be used for the base signature string.
+   * <p>
+   * If the payload is going to be {@code application/x-www-url-form-encoded} then the request body
+   * also needs to be included in the signature base string. You would specify a filter that gives
+   * you the parameters; and subsequently use a
+   * {@link com.adaptris.core.services.metadata.FormDataFromMetadata} to generate the payload.
+   * </p>
+   * 
+   * @param filter a filter on metadata.
+   */
   public void setAdditionalData(MetadataFilter filter) {
     this.additionalData = filter;
   }

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/StandardRfc5849Authenticator.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/rfc5849/StandardRfc5849Authenticator.java
@@ -43,6 +43,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * {@link HttpURLConnectionAuthenticator} implementation for you to add as the
  * {@link HttpRequestService#setAuthenticator(HttpAuthenticator)} or similar.
  * </p>
+ * <p>
+ * Note that since this will not have access to payload; this particular implementation does not
+ * support the using the payload as part of the signature base string when the {@code Content-Type}
+ * is {@code application/x-www-form-urlencoded}. If that is the case then use a
+ * {@link GenerateRfc5849Header} with a metadata filter to pre-build an authorisation header.
+ * </p>
  * 
  * @config oauth-rfc5849-authenticator
  */

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/rfc5849/OauthAuthorizationBuilderTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/rfc5849/OauthAuthorizationBuilderTest.java
@@ -26,8 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.oauth.rfc5849.AuthorizationData;
-import com.adaptris.core.oauth.rfc5849.AuthorizationBuilder;
 import com.adaptris.core.oauth.rfc5849.AuthorizationData.SignatureMethod;
 
 public class OauthAuthorizationBuilderTest {
@@ -84,6 +82,23 @@ public class OauthAuthorizationBuilderTest {
     assertEquals("\"\"", params.get("oauth_verifier"));
   }
 
+  @Test
+  public void testBuild_NoAccessToken() throws Exception {
+    AuthorizationData data = new AuthorizationData();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    data.setConsumerKey("consumerKey");
+    data.setConsumerSecret("consumerSecret");
+    AuthorizationBuilder builder = data.builder("POST", new URL("http://localhost"), msg);
+    String authString = builder.build();
+    assertNotNull(authString);
+    assertTrue(authString.startsWith("OAuth"));
+    System.out.println(authString);
+    Map<String, String> params = unsplitAuthorization(authString.replace("OAuth ", ""));
+    assertEquals(StringUtils.wrap("consumerKey", '"'), params.get("oauth_consumer_key"));
+    assertEquals(StringUtils.wrap("1.0", '"'), params.get("oauth_version"));
+    assertNotNull(params.get("oauth_timestamp"));
+    assertNotNull(params.get("oauth_signature"));
+  }
 
   private static Map<String, String> unsplitAuthorization(String auth) {
     return Arrays.stream(auth.split(",")).map(s -> s.split("=")).collect(Collectors.toMap(

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/rfc5849/OauthAuthorizationServiceTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/rfc5849/OauthAuthorizationServiceTest.java
@@ -21,7 +21,7 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.oauth.rfc5849.GenerateRfc5849Header;
+import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.util.LifecycleHelper;
 
 public class OauthAuthorizationServiceTest extends ServiceCase {
@@ -43,9 +43,8 @@ public class OauthAuthorizationServiceTest extends ServiceCase {
 
   @Test
   public void testService_Exception() throws Exception {
-    GenerateRfc5849Header service = new GenerateRfc5849Header();
-    service.setHttpMethod("POST");
-    service.setUrl("http://localhost");
+    GenerateRfc5849Header service =
+        new GenerateRfc5849Header().withMethod("POST").withUrl("http://localhost");
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("Hello World");
     try {
       ServiceCase.execute(service, msg);
@@ -56,9 +55,8 @@ public class OauthAuthorizationServiceTest extends ServiceCase {
 
   @Test
   public void testService() throws Exception {
-    GenerateRfc5849Header service = new GenerateRfc5849Header();
-    service.setHttpMethod("POST");
-    service.setUrl("http://localhost");
+    GenerateRfc5849Header service =
+        new GenerateRfc5849Header().withMethod("POST").withUrl("http://localhost");
     AuthorizationDataTest.configure(service.getAuthorizationData());
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("Hello World");
     ServiceCase.execute(service, msg);
@@ -69,16 +67,28 @@ public class OauthAuthorizationServiceTest extends ServiceCase {
 
   @Test
   public void testService_TargetMetadataKey() throws Exception {
-    GenerateRfc5849Header service = new GenerateRfc5849Header();
-    service.setHttpMethod("POST");
-    service.setUrl("http://localhost");
-    service.setTargetMetadataKey("X-Authorization");
-    AuthorizationDataTest.configure(service.getAuthorizationData());
+    GenerateRfc5849Header service =
+        new GenerateRfc5849Header().withMethod("POST").withUrl("http://localhost")
+            .withTargetMetadataKey("X-Authorization")
+            .withAuthorizationData(AuthorizationDataTest.configure(new AuthorizationData()));
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("Hello World");
     ServiceCase.execute(service, msg);
     assertNull(msg.getMetadataValue("Authorization"));
     assertNotNull(msg.getMetadataValue("X-Authorization"));
     assertTrue(msg.getMetadataValue("X-Authorization").startsWith("OAuth"));
+  }
+
+  @Test
+  public void testService_AdditionalData() throws Exception {
+    GenerateRfc5849Header service =
+        new GenerateRfc5849Header().withMethod("POST").withUrl("http://localhost")
+            .withAdditionalData(new NoOpMetadataFilter());
+    AuthorizationDataTest.configure(service.getAuthorizationData());
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("Hello World");
+    msg.addMetadata("Hello", "World");
+    ServiceCase.execute(service, msg);
+    assertNotNull(msg.getMetadataValue("Authorization"));
+    assertTrue(msg.getMetadataValue("Authorization").startsWith("OAuth"));
   }
 
 


### PR DESCRIPTION
- Made accessToken & tokenSecret optional in AuthData
- If not specified, then oauth_token is never emitted, and token-secret
is never used as part of the signing key.
- Of course if "include-empty-params==true" then you will get the
oauth_token field.

- There might be change required in the sense that it's not clear from
the RFC if the signing key should include the &  if token-secret is not
present.