### PR TITLE
INTERLOK-3225 Remove use of deprecated AccessToken constructors

### DIFF
--- a/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureAccessTokenImpl.java
+++ b/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureAccessTokenImpl.java
@@ -20,7 +20,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.hibernate.validator.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.AdvancedConfig;
@@ -111,8 +113,8 @@ public abstract class AzureAccessTokenImpl implements AccessTokenBuilder {
     AccessToken token = null;
     try {
       AuthenticationResult azureToken = doAzureAuth(msg);
-      token = new AccessToken(azureToken.getAccessTokenType(), azureToken.getAccessToken(),
-          azureToken.getExpiresOnDate().getTime()).withRefreshToken(azureToken.getRefreshToken());
+      token = new AccessToken(azureToken.getAccessTokenType(), azureToken.getAccessToken())
+          .withExpiry(azureToken.getExpiresOnDate()).withRefreshToken(azureToken.getRefreshToken());
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
@@ -134,7 +136,7 @@ public abstract class AzureAccessTokenImpl implements AccessTokenBuilder {
   }
 
   String authorityUrl() {
-    return getAuthorityUrl() != null ? getAuthorityUrl() : DEFAULT_AUTHORITY;
+    return StringUtils.defaultIfEmpty(getAuthorityUrl(), DEFAULT_AUTHORITY);
   }
 
   public String getClientId() {
@@ -175,7 +177,7 @@ public abstract class AzureAccessTokenImpl implements AccessTokenBuilder {
   }
 
   boolean validateAuthority() {
-    return getValidateAuthority() != null ? getValidateAuthority().booleanValue() : false;
+    return BooleanUtils.toBooleanDefaultIfNull(getValidateAuthority(), false);
   }
 
   protected AuthenticationContext authenticationContext(AdaptrisMessage msg) throws MalformedURLException {

--- a/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureClientSecretAccessToken.java
+++ b/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureClientSecretAccessToken.java
@@ -17,9 +17,7 @@
 package com.adaptris.core.oauth.azure;
 
 import java.util.concurrent.Future;
-
-import org.hibernate.validator.constraints.NotBlank;
-
+import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureUsernamePasswordAccessToken.java
+++ b/interlok-oauth-azure/src/main/java/com/adaptris/core/oauth/azure/AzureUsernamePasswordAccessToken.java
@@ -17,9 +17,7 @@
 package com.adaptris.core.oauth.azure;
 
 import java.util.concurrent.Future;
-
-import org.hibernate.validator.constraints.NotBlank;
-
+import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-oauth-gcloud/src/main/java/com/adaptris/core/oauth/gcloud/GoogleCloudAccessTokenBuilder.java
+++ b/interlok-oauth-gcloud/src/main/java/com/adaptris/core/oauth/gcloud/GoogleCloudAccessTokenBuilder.java
@@ -18,10 +18,8 @@ package com.adaptris.core.oauth.gcloud;
 
 
 import java.io.IOException;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -53,7 +51,7 @@ public class GoogleCloudAccessTokenBuilder implements AccessTokenBuilder {
     try {
       GoogleCredentials credential = getCredentials().build();
       com.google.auth.oauth2.AccessToken accessToken = credential.refreshAccessToken();
-      return new AccessToken(accessToken.getTokenValue(), accessToken.getExpirationTime().getTime());
+      return new AccessToken(accessToken.getTokenValue()).withExpiry(accessToken.getExpirationTime());
     } catch (Exception e) {
       throw new ServiceException("Failed to retrieve credentials", e);
     }

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/ResponseHandlerImpl.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/ResponseHandlerImpl.java
@@ -16,6 +16,7 @@
 package com.adaptris.core.oauth.generic;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.InputFieldDefault;
@@ -128,15 +129,11 @@ public abstract class ResponseHandlerImpl implements OauthResponseHandler {
 
 
   protected static void applyIfNotBlank(String value, Consumer<String> f) {
-    if (!isBlank(value)) {
-      f.accept(value);
-    }
+    Optional.ofNullable(value).filter((s) -> !isBlank(s)).ifPresent(f);
   }
 
 
   protected static void applyIfNotNull(String value, Consumer<String> f) {
-    if (value != null) {
-      f.accept(value);
-    }
+    Optional.ofNullable(value).ifPresent(f);
   }
 }

--- a/interlok-oauth-salesforce/src/test/java/com/adaptris/core/oauth/salesforce/SalesforceAccessTokenTest.java
+++ b/interlok-oauth-salesforce/src/test/java/com/adaptris/core/oauth/salesforce/SalesforceAccessTokenTest.java
@@ -185,7 +185,7 @@ public class SalesforceAccessTokenTest {
     tokenBuilder.setPassword("test");
     tokenBuilder.setConsumerKey("test");
     tokenBuilder.setConsumerSecret("test");
-    AccessToken myAccessToken = new AccessToken("Bearer", "token", -1);
+    AccessToken myAccessToken = new AccessToken("Bearer", "token");
     when(worker.login((HttpEntity) anyObject())).thenReturn(myAccessToken);
     try {
       LifecycleHelper.initAndStart(tokenBuilder);
@@ -209,7 +209,7 @@ public class SalesforceAccessTokenTest {
     tokenBuilder.setPassword("PW:test");
     tokenBuilder.setConsumerKey("test");
     tokenBuilder.setConsumerSecret("test");
-    AccessToken myAccessToken = new AccessToken("Bearer", "token", -1);
+    AccessToken myAccessToken = new AccessToken("Bearer", "token");
     when(worker.login((HttpEntity) anyObject())).thenReturn(myAccessToken);
     try {
       LifecycleHelper.initAndStart(tokenBuilder);


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok/pull/416 deprecated the AccessToken constructors that
have a 'long' associated with it. These are used by the various oauth optional components.

Since Azure + Gcloud provide the "token expiry" as a Date already, we should just use the withExpiry(Date) method to remove dependency on a deprecated method.

## Modification

- Switch where appropriate to use the withExpiry(Date) on AccessToken
- Remove use hibernate-validator @NotBlank in favour of the real javax.validation one

## Result

No Regressions in the Unit tests; no behavioural change for the user.

## Testing

Test it with MS Graph (see https://github.com/adaptris/interlok/pull/416)