### PR TITLE
Interlok 3440+3447 json payload and http status propogation

### DIFF
--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
@@ -65,7 +65,7 @@ import lombok.Setter;
  */
 @DisplayOrder(order =
 {
-    "tokenUrl", "responseHandler", "formBuilder", "clientConfig"
+    "tokenUrl", "responseHandler", "formBuilder", "clientConfig", "additionalHttpHeaders"
 })
 @ComponentProfile(since = "3.11.1",
     summary = "Get a bearer token based on a URL Form based OAuth authentication flow.",

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
@@ -60,7 +60,7 @@ import lombok.Setter;
  * {@link com.adaptris.core.metadata.CompositeMetadataFilter}.
  * </p>
  *
- * @config generic-oauth-access-token
+ * @config oauth-access-token-via-form
  * @see AccessTokenBuilder
  */
 @DisplayOrder(order =

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/FormBasedAccessToken.java
@@ -16,19 +16,23 @@
 
 package com.adaptris.core.oauth.generic;
 
-import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.message.BasicNameValuePair;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.Removal;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.http.oauth.AccessTokenBuilder;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
-import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -57,62 +61,50 @@ import lombok.Setter;
  * </p>
  *
  * @config generic-oauth-access-token
- * @deprecated since 3.11.1 poorly named since we can get an access token via a form or a JSON
- *             payload, use {@link FormBasedAccessToken} instead.
  * @see AccessTokenBuilder
  */
 @DisplayOrder(order =
 {
     "tokenUrl", "responseHandler", "formBuilder", "clientConfig"
 })
-@ComponentProfile(since = "3.8.1", summary = "Get a bearer token based on a URL Form based OAuth authentication flow.", tag = "oauth,http,https")
-@XStreamAlias("generic-oauth-access-token")
-@Deprecated
-@Removal(version = "4.0.0", message = "use 'oauth-access-token-via-form' instead")
-public class GenericAccessToken extends FormBasedAccessToken {
+@ComponentProfile(since = "3.11.1",
+    summary = "Get a bearer token based on a URL Form based OAuth authentication flow.",
+    tag = "oauth,http,https")
+@XStreamAlias("oauth-access-token-via-form")
+@NoArgsConstructor
+public class FormBasedAccessToken extends GenericAccessTokenImpl {
 
   /**
-   * The metadata that will be used to build up the payload will be sent to the specified URL.
-   *
-   * @deprecated since 3.11.0; this member was poorly named, use 'formBuilder' instead.
+   * The form builder will be used to build up the payload will be sent to the specified URL.
+   * <p>
+   * By default the payload is built up from the metadata keys 'client_id', 'client_secret',
+   * 'grant_type','refresh_token','username', 'password' using a {@link RegexMetadataFilter}. You
+   * should change this if these are not the right keys (keys that aren't present in metadata will
+   * be ignored).
+   * </p>
    */
   @Valid
+  @InputFieldDefault(
+      value = "regex-metadata-filter with 'client_id', 'client_secret', 'grant_type','refresh_token','username', 'password'")
   @Getter
   @Setter
-  @Deprecated
-  @Removal(version="4.0", message="Poorly named use 'form-builder' instead")
-  private MetadataFilter metadataFilter;
+  private MetadataFilter formBuilder;
 
-  private transient boolean filterWarning;
-  private transient boolean deprecationWarning;
-
-  public GenericAccessToken() {
-    setFormBuilder(new RegexMetadataFilter().withIncludePatterns(DEFAULT_METADATA_PATTERNS));
-  }
 
   @Override
-  public void init() throws CoreException {
-    LoggingHelper.logDeprecation(deprecationWarning, () -> deprecationWarning = true,
-        getClass().getCanonicalName(),
-        FormBasedAccessToken.class.getCanonicalName());
-    if (getMetadataFilter() != null) {
-      LoggingHelper.logWarning(filterWarning, () -> filterWarning = true,
-          "{} uses metadata-filter which is deprecated; use 'form-builder' instead",
-          LoggingHelper.friendlyName(this));
-    }
-    super.init();
+  protected HttpEntity buildEntity(AdaptrisMessage msg) throws Exception {
+    return new UrlEncodedFormEntity(formBuilder().filter(msg).stream()
+        .map(e -> new BasicNameValuePair(e.getKey(), e.getValue())).collect(Collectors.toList()));
   }
 
-  public GenericAccessToken withMetadataFilter(MetadataFilter f) {
-    return withFormBuilder(f);
+  public <T extends FormBasedAccessToken> T withFormBuilder(MetadataFilter f) {
+    setFormBuilder(f);
+    return (T) this;
   }
 
-  @Override
   protected MetadataFilter formBuilder() throws CoreException {
-    MetadataFilter filter = ObjectUtils.defaultIfNull(getMetadataFilter(), getFormBuilder());
-    return Optional.ofNullable(filter).orElseThrow(
-        () -> new CoreException(
-            "No way to build OAUTH form entity; no metadata-filter or form-builder"));
+    return ObjectUtils.defaultIfNull(getFormBuilder(),
+        new RegexMetadataFilter().withIncludePatterns(DEFAULT_METADATA_PATTERNS));
   }
 
 }

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessToken.java
@@ -63,7 +63,7 @@ import lombok.Setter;
  */
 @DisplayOrder(order =
 {
-    "tokenUrl", "responseHandler", "formBuilder", "clientConfig"
+    "tokenUrl", "responseHandler", "formBuilder", "clientConfig", "additionalHttpHeaders"
 })
 @ComponentProfile(since = "3.8.1", summary = "Get a bearer token based on a URL Form based OAuth authentication flow.", tag = "oauth,http,https")
 @XStreamAlias("generic-oauth-access-token")

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessToken.java
@@ -16,50 +16,25 @@
 
 package com.adaptris.core.oauth.generic;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.message.BasicStatusLine;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
-import com.adaptris.core.http.oauth.AccessToken;
 import com.adaptris.core.http.oauth.AccessTokenBuilder;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
-import com.adaptris.core.util.Args;
-import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Setter;
 
 /**
@@ -94,21 +69,8 @@ import lombok.Setter;
 })
 @ComponentProfile(since = "3.8.1", summary = "Get a bearer token based on a URL Form based OAuth authentication flow.", tag = "oauth,http,https")
 @XStreamAlias("generic-oauth-access-token")
-public class GenericAccessToken implements AccessTokenBuilder {
-  private static final StatusLine DEFAULT_STATUS = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
+public class GenericAccessToken extends GenericAccessTokenImpl {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
-
-  /**
-   * The URL that will be used the retrieve the OAUTH access token.
-   *
-   */
-  @NotBlank
-  @InputFieldHint(expression = true)
-  @Getter
-  @Setter
-  @NonNull
-  private String tokenUrl;
   /**
    * The metadata that will be used to build up the payload will be sent to the specified URL.
    *
@@ -137,118 +99,40 @@ public class GenericAccessToken implements AccessTokenBuilder {
   @Setter
   private MetadataFilter formBuilder;
 
-  /**
-   * How to handle the response from the server.
-   * <p>
-   * By default we assume a JSON based response, generally, this is the right thing
-   * </p>
-   */
-  @NotNull
-  @Valid
-  @AutoPopulated
-  @InputFieldDefault (value = "json based responses")
-  @Getter
-  @Setter
-  @NonNull
-  private OauthResponseHandler responseHandler;
-  /**
-   * Additional configuration that will be applied to the underlying Apache HTTP instance.
-   *
-   */
-  @Valid
-  @AdvancedConfig
-  @Getter
-  @Setter
-  private HttpClientBuilderConfigurator clientConfig;
 
   private transient boolean filterWarning;
 
   public GenericAccessToken() {
     setFormBuilder(new RegexMetadataFilter().withIncludePatterns("client_id", "client_secret",
         "grant_type", "refresh_token", "username", "password"));
-    setResponseHandler(new JsonResponseHandler());
   }
 
   @Override
   public void init() throws CoreException {
-    Args.notBlank(getTokenUrl(), "tokenUrl");
-    Args.notNull(getResponseHandler(), "responseHandler");
     if (getMetadataFilter() != null) {
       LoggingHelper.logWarning(filterWarning, () -> filterWarning = true,
           "{} uses metadata-filter which is deprecated; use 'form-builder' instead",
           LoggingHelper.friendlyName(this));
     }
-    LifecycleHelper.init(getResponseHandler());
+    super.init();
   }
 
   @Override
-  public void start() throws CoreException {
-    LifecycleHelper.start(getResponseHandler());
+  protected HttpEntity buildEntity(AdaptrisMessage msg) throws Exception {
+    return new UrlEncodedFormEntity(formBuilder().filter(msg).stream()
+        .map(e -> new BasicNameValuePair(e.getKey(), e.getValue())).collect(Collectors.toList()));
   }
 
-  @Override
-  public void stop() {
-    LifecycleHelper.stop(getResponseHandler());
-  }
-
-  @Override
-  public void close() {
-    LifecycleHelper.close(getResponseHandler());
-  }
-
-  @Override
-  public AccessToken build(AdaptrisMessage msg) throws CoreException {
-    AccessToken token = null;
-    try {
-      String url = msg.resolve(getTokenUrl());
-      HttpEntity entity = new UrlEncodedFormEntity(formBuilder().filter(msg).stream()
-          .map(e -> new BasicNameValuePair(e.getKey(), e.getValue())).collect(Collectors.toList()));
-      token = login(url, entity);
-    }
-    catch (Exception e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
-    return token;
-  }
-
-  private AccessToken login(String url, HttpEntity entity) throws Exception {
-    String responseBody = "";
-    String httpStatusLine = "";
-
-    try (CloseableHttpClient httpclient = HttpClientBuilderConfigurator.defaultIfNull(getClientConfig())
-        .configure(HttpClients.custom())
-        .build()) {
-      HttpPost post = new HttpPost(url);
-      post.setEntity(entity);
-      CustomResponseHandler responseHandler = new CustomResponseHandler();
-      responseBody = httpclient.execute(post, responseHandler);
-      httpStatusLine = responseHandler.statusLine();
-      responseHandler.throwExceptionIfAny();
-      return getResponseHandler().buildToken(responseBody);
-    } catch (Exception e) {
-      log.error("Failed to authenticate, got [{}], HTTP Reply data was : [{}]", httpStatusLine, responseBody);
-      throw e;
-    }
-  }
-
-  public GenericAccessToken withTokenUrl(String url) {
-    setTokenUrl(url);
-    return this;
-  }
 
   // Make this use the FormBuilder setter.
+  @Deprecated
+  @Removal(version = "4.0.0")
   public GenericAccessToken withMetadataFilter(MetadataFilter f) {
+    return withFormBuilder(f);
+  }
+
+  public GenericAccessToken withFormBuilder(MetadataFilter f) {
     setFormBuilder(f);
-    return this;
-  }
-
-  public GenericAccessToken withResponseHandler(OauthResponseHandler f) {
-    setResponseHandler(f);
-    return this;
-  }
-
-  public GenericAccessToken withClientConfig(HttpClientBuilderConfigurator f) {
-    setClientConfig(f);
     return this;
   }
 
@@ -259,25 +143,4 @@ public class GenericAccessToken implements AccessTokenBuilder {
             "No way to build OAUTH form entity; no metadata-filter or form-builder"));
   }
 
-
-  protected static class CustomResponseHandler implements ResponseHandler<String> {
-
-    private StatusLine statusLine = DEFAULT_STATUS;
-
-    @Override
-    public String handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
-      statusLine = response.getStatusLine();
-      return EntityUtils.toString(response.getEntity());
-    }
-
-    protected String statusLine() {
-      return statusLine.toString();
-    }
-
-    protected void throwExceptionIfAny() throws HttpResponseException {
-      if (statusLine.getStatusCode() >= 300) {
-        throw new HttpResponseException(statusLine.getStatusCode(), statusLine.getReasonPhrase());
-      }
-    }
-  }
 }

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessTokenImpl.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessTokenImpl.java
@@ -61,6 +61,9 @@ public abstract class GenericAccessTokenImpl implements AccessTokenBuilder {
   protected static final StatusLine DEFAULT_STATUS =
       new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
 
+  protected static final String[] DEFAULT_METADATA_PATTERNS =
+      {"client_id", "client_secret", "grant_type", "refresh_token", "username", "password"};
+
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());
 
   /**

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessTokenImpl.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/GenericAccessTokenImpl.java
@@ -1,0 +1,210 @@
+/*
+    Copyright Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.oauth.generic;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
+import com.adaptris.core.http.oauth.AccessToken;
+import com.adaptris.core.http.oauth.AccessTokenBuilder;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Baseline behaviour for getting OAUTh tokens.
+ *
+ * @see AccessTokenBuilder
+ */
+public abstract class GenericAccessTokenImpl implements AccessTokenBuilder {
+  protected static final StatusLine DEFAULT_STATUS =
+      new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
+
+  protected transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  /**
+   * The URL that will be used the retrieve the OAUTH access token.
+   *
+   */
+  @NotBlank
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @NonNull
+  private String tokenUrl;
+
+  /**
+   * How to handle the response from the server.
+   * <p>
+   * By default we assume a JSON based response, generally, this is the right thing
+   * </p>
+   */
+  @NotNull
+  @Valid
+  @AutoPopulated
+  @InputFieldDefault (value = "json based responses")
+  @Getter
+  @Setter
+  @NonNull
+  private OauthResponseHandler responseHandler;
+  /**
+   * Additional configuration that will be applied to the underlying Apache HTTP instance.
+   *
+   */
+  @Valid
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private HttpClientBuilderConfigurator clientConfig;
+
+  private transient boolean filterWarning;
+
+  public GenericAccessTokenImpl() {
+    setResponseHandler(new JsonResponseHandler());
+  }
+
+  @Override
+  public void init() throws CoreException {
+    Args.notBlank(getTokenUrl(), "tokenUrl");
+    Args.notNull(getResponseHandler(), "responseHandler");
+    LifecycleHelper.init(getResponseHandler());
+  }
+
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(getResponseHandler());
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getResponseHandler());
+  }
+
+  @Override
+  public void close() {
+    LifecycleHelper.close(getResponseHandler());
+  }
+
+  @Override
+  public AccessToken build(AdaptrisMessage msg) throws CoreException {
+    AccessToken token = null;
+    try {
+      String url = msg.resolve(getTokenUrl());
+      HttpEntity entity = buildEntity(msg);
+      token = login(url, entity,
+          (code) -> msg.addMetadata(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, code.toString()));
+    }
+    catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+    return token;
+  }
+
+  protected abstract HttpEntity buildEntity(AdaptrisMessage msg) throws Exception;
+
+  protected AccessToken login(String url, HttpEntity entity, Consumer<Integer> httpStatusCallback)
+      throws Exception {
+    String responseBody = "";
+    String httpStatusLine = "";
+
+    try (CloseableHttpClient httpclient = HttpClientBuilderConfigurator
+        .defaultIfNull(getClientConfig()).configure(HttpClients.custom()).build()) {
+      HttpPost post = new HttpPost(url);
+      post.setEntity(entity);
+      CustomResponseHandler responseHandler = new CustomResponseHandler(httpStatusCallback);
+      responseBody = httpclient.execute(post, responseHandler);
+      httpStatusLine = responseHandler.statusLine();
+      responseHandler.throwExceptionIfAny();
+      return getResponseHandler().buildToken(responseBody);
+    } catch (Exception e) {
+      log.error("Failed to authenticate, got [{}], HTTP Reply data was : [{}]", httpStatusLine,
+          responseBody);
+      throw e;
+    }
+  }
+
+  public GenericAccessTokenImpl withTokenUrl(String url) {
+    setTokenUrl(url);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends GenericAccessTokenImpl> T withResponseHandler(OauthResponseHandler f) {
+    setResponseHandler(f);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends GenericAccessTokenImpl> T withClientConfig(HttpClientBuilderConfigurator f) {
+    setClientConfig(f);
+    return (T) this;
+  }
+
+  protected static class CustomResponseHandler implements ResponseHandler<String> {
+
+    private transient StatusLine statusLine = DEFAULT_STATUS;
+    private transient Consumer<Integer> responseCallback;
+
+    public CustomResponseHandler(Consumer<Integer> callback) {
+      responseCallback = Args.notNull(callback, "httpResponseCallback");
+    }
+
+    @Override
+    public String handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
+      statusLine = response.getStatusLine();
+      responseCallback.accept(statusLine.getStatusCode());
+      return EntityUtils.toString(response.getEntity());
+    }
+
+    protected String statusLine() {
+      return statusLine.toString();
+    }
+
+    protected void throwExceptionIfAny() throws HttpResponseException {
+      if (statusLine.getStatusCode() >= 300) {
+        throw new HttpResponseException(statusLine.getStatusCode(), statusLine.getReasonPhrase());
+      }
+    }
+  }
+}

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
@@ -52,7 +52,7 @@ import lombok.Setter;
  * {@link com.adaptris.core.metadata.CompositeMetadataFilter}.
  * </p>
  *
- * @config generic-oauth-access-token
+ * @config oauth-access-token-via-json
  * @see AccessTokenBuilder
  */
 @DisplayOrder(order =

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
@@ -57,7 +57,7 @@ import lombok.Setter;
  */
 @DisplayOrder(order =
 {
-    "tokenUrl", "responseHandler", "jsonContent", "clientConfig"
+    "tokenUrl", "responseHandler", "jsonContent", "clientConfig", "additionalHttpHeaders"
 })
 @ComponentProfile(since = "3.11.1",
     summary = "Get a OAUTH token by POSTing a JSON payload to the specified URL.",
@@ -82,6 +82,7 @@ public class JsonBasedAccessToken extends GenericAccessTokenImpl {
   @Getter
   @Setter
   private MetadataFilter contentBuilder;
+
 
   @Override
   protected HttpEntity buildEntity(AdaptrisMessage msg) throws Exception {

--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/JsonBasedAccessToken.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.adaptris.core.oauth.generic;
+
+import javax.validation.Valid;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.http.oauth.AccessTokenBuilder;
+import com.adaptris.core.metadata.MetadataFilter;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Wraps the a URL Form based OAuth authentication flow.
+ * <p>
+ * This class is designed for the situation where the OAUTH provider does not have a specific API
+ * that we can use. The sequence of events is :
+ * </p>
+ * <ul>
+ * <li>Filter the metadata to create a JSON payload; the JSON payload is build exlusively from the
+ * metadata keys specified.</li>
+ * <li>Post this to the configured URL.</li>
+ * <li>Extract the access token information via the configured OauthResponseHandler</li>
+ * <li>This then is your access token</li>
+ * </p>
+ * <p>
+ * It is perfectly possible to achieve the same thing with standard configuration; This encapsulates
+ * all of that into a single class. If you have encoded passwords in your metadata, consider using a
+ * {@link com.adaptris.core.metadata.PasswordDecodeMetadataFilter} as part of a
+ * {@link com.adaptris.core.metadata.CompositeMetadataFilter}.
+ * </p>
+ *
+ * @config generic-oauth-access-token
+ * @see AccessTokenBuilder
+ */
+@DisplayOrder(order =
+{
+    "tokenUrl", "responseHandler", "jsonContent", "clientConfig"
+})
+@ComponentProfile(since = "3.11.1",
+    summary = "Get a OAUTH token by POSTing a JSON payload to the specified URL.",
+    tag = "oauth,http,https,json")
+@XStreamAlias("oauth-access-token-via-json")
+@NoArgsConstructor
+public class JsonBasedAccessToken extends GenericAccessTokenImpl {
+
+  /**
+   * The metadata filter that will be used to build up the payload will be sent to the specified
+   * URL.
+   * <p>
+   * By default the payload is built up from the metadata keys 'client_id', 'client_secret',
+   * 'grant_type','refresh_token','username', 'password' using a {@link RegexMetadataFilter}. You
+   * should change this if these are not the right keys (keys that aren't present in metadata will
+   * be ignored).
+   * </p>
+   */
+  @Valid
+  @InputFieldDefault(
+      value = "regex-metadata-filter with 'client_id', 'client_secret', 'grant_type','refresh_token','username', 'password'")
+  @Getter
+  @Setter
+  private MetadataFilter contentBuilder;
+
+  @Override
+  protected HttpEntity buildEntity(AdaptrisMessage msg) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    //
+    // String json = mapper.writeValueAsString(contentBuilder().filter(msg).stream()
+    // .collect(Collectors.toMap(MetadataElement::getKey, MetadataElement::getValue)));
+
+    // There's already a utility method to convert to a map.
+    String json = mapper.writeValueAsString(MetadataCollection.asMap(contentBuilder().filter(msg)));
+    return new StringEntity(json, ContentType.APPLICATION_JSON);
+  }
+
+  public JsonBasedAccessToken withContentBuilder(MetadataFilter f) {
+    setContentBuilder(f);
+    return this;
+  }
+
+  private MetadataFilter contentBuilder() {
+    return ObjectUtils.defaultIfNull(getContentBuilder(),
+        new RegexMetadataFilter().withIncludePatterns(DEFAULT_METADATA_PATTERNS));
+  }
+
+}

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/FormBasedAccessTokenTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/FormBasedAccessTokenTest.java
@@ -1,0 +1,101 @@
+/*
+    Copyright Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.oauth.generic;
+import static com.adaptris.core.oauth.generic.JsonResponseHandlerTest.ACCESS_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.http.oauth.GetOauthToken;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.oauth.generic.GenericAccessTokenImplTest.MyHttpClientBuilderConfigurator;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+@SuppressWarnings("deprecation")
+public class FormBasedAccessTokenTest extends ExampleServiceCase {
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    GetOauthToken service = new GetOauthToken();
+    service.setAccessTokenBuilder(
+        new FormBasedAccessToken()
+            .withFormBuilder(
+                new RegexMetadataFilter()
+                    .withIncludePatterns(GenericAccessTokenImpl.DEFAULT_METADATA_PATTERNS))
+            .withResponseHandler(new JsonResponseHandler())
+            .withTokenUrl("http://my-oauth-server.com/oauth"));
+    return service;
+  }
+
+  @Test
+  public void testLifecycle() throws Exception {
+    GetOauthToken service = new GetOauthToken();
+    FormBasedAccessToken tokenBuilder = new FormBasedAccessToken();
+    tokenBuilder.withTokenUrl("http://localhost:1234")
+        .withResponseHandler(new JsonResponseHandler());
+    service.setAccessTokenBuilder(tokenBuilder);
+    try {
+      LifecycleHelper.initAndStart(service);
+    } finally {
+      LifecycleHelper.stopAndClose(service);
+    }
+  }
+
+  @Test
+  public void testLogin() throws Exception {
+    GetOauthToken service = new GetOauthToken();
+    service.setAccessTokenBuilder(new FormBasedAccessToken()
+        .withResponseHandler(new JsonResponseHandler())
+            .withTokenUrl("http://localhost:1234")
+            .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, false)));
+    try {
+      LifecycleHelper.initAndStart(service);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      msg.addMessageHeader("hello", "world");
+      msg.addMessageHeader("password", "MyPassword");
+      msg.addMessageHeader("client_id", "MyClientId");
+      service.doService(msg);
+      String bearerToken = "Bearer token";
+      assertEquals(bearerToken, msg.getMetadataValue("Authorization"));
+    } finally {
+      LifecycleHelper.stopAndClose(service);
+    }
+  }
+
+
+  @Test
+  public void testLogin_WithError() throws Exception {
+    GetOauthToken service = new GetOauthToken();
+    service
+        .setAccessTokenBuilder(new FormBasedAccessToken()
+        .withResponseHandler(new JsonResponseHandler()).withTokenUrl("http://localhost:1234")
+            .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, true)));
+    try {
+      LifecycleHelper.initAndStart(service);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      service.doService(msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    } finally {
+      LifecycleHelper.stopAndClose(service);
+    }
+  }
+}

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/FormBasedAccessTokenTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/FormBasedAccessTokenTest.java
@@ -23,6 +23,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.http.oauth.GetOauthToken;
+import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.adaptris.core.oauth.generic.GenericAccessTokenImplTest.MyHttpClientBuilderConfigurator;
 import com.adaptris.core.util.LifecycleHelper;
@@ -64,6 +65,7 @@ public class FormBasedAccessTokenTest extends ExampleServiceCase {
     service.setAccessTokenBuilder(new FormBasedAccessToken()
         .withResponseHandler(new JsonResponseHandler())
             .withTokenUrl("http://localhost:1234")
+            .withAdditionalHeaders(new NoOpMetadataFilter())
             .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, false)));
     try {
       LifecycleHelper.initAndStart(service);

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericAccessTokenImplTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericAccessTokenImplTest.java
@@ -44,6 +44,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
 import com.adaptris.core.http.oauth.AccessToken;
 import com.adaptris.core.util.LifecycleHelper;
@@ -109,7 +110,8 @@ public class GenericAccessTokenImplTest extends GenericAccessToken {
   }
 
   @Override
-  protected AccessToken login(String url, HttpEntity entity, Consumer<Integer> httpStatusCallback) {
+  protected AccessToken login(String url, HttpEntity entity, MetadataCollection httpHeaders,
+      Consumer<Integer> httpStatusCallback) {
     AccessToken token = new AccessToken("token");
     Optional.ofNullable(httpStatusCallback).ifPresent((c) -> c.accept(200));
     return new AccessToken("token");

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericAccessTokenImplTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericAccessTokenImplTest.java
@@ -1,0 +1,156 @@
+/*
+    Copyright Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.oauth.generic;
+import static com.adaptris.core.oauth.generic.JsonResponseHandlerTest.ACCESS_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
+import com.adaptris.core.http.oauth.AccessToken;
+import com.adaptris.core.util.LifecycleHelper;
+
+@SuppressWarnings("deprecation")
+public class GenericAccessTokenImplTest extends GenericAccessToken {
+
+  @Test
+  public void testLogin() throws Exception {
+    GenericAccessTokenImpl tokenBuilder = this;
+    try {
+      LifecycleHelper.initAndStart(tokenBuilder);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      msg.addMessageHeader(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, "-1");
+      msg.addMessageHeader("password", "MyPassword");
+      msg.addMessageHeader("client_id", "MyClientId");
+      AccessToken token = tokenBuilder.build(msg);
+      assertEquals("token", token.getToken());
+      assertEquals("Bearer", token.getType());
+      assertEquals("200", msg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+    } finally {
+      LifecycleHelper.stopAndClose(tokenBuilder);
+    }
+  }
+
+  @Test
+  public void testCustomResponseHandler() throws Exception {
+    BasicStatusLine status = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK");
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    HttpEntity mockEntity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(mockEntity);
+    when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(ACCESS_TOKEN));
+    when(response.getStatusLine()).thenReturn(status);
+
+
+    CustomResponseHandler handler = new CustomResponseHandler((i) -> {
+    });
+    assertEquals(ACCESS_TOKEN, handler.handleResponse(response));
+    assertNotNull(handler.statusLine());
+    assertTrue(handler.statusLine().contains("HTTP/1.1"));
+    handler.throwExceptionIfAny();
+  }
+
+  @Test
+  public void testCustomResponseHandler_NotFound() throws Exception {
+    BasicStatusLine status = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_NOT_FOUND, "Not Found");
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    HttpEntity mockEntity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(mockEntity);
+    when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(ACCESS_TOKEN));
+    when(response.getStatusLine()).thenReturn(status);
+    final AtomicInteger httpStatus = new AtomicInteger(1);
+    try {
+      CustomResponseHandler handler = new CustomResponseHandler((i) -> httpStatus.set(i));
+      assertEquals(ACCESS_TOKEN, handler.handleResponse(response));
+      assertNotNull(handler.statusLine());
+      assertTrue(handler.statusLine().contains("HTTP/1.1"));
+      handler.throwExceptionIfAny();
+      fail();
+    } catch (HttpResponseException expected) {
+      assertEquals(HttpStatus.SC_NOT_FOUND, httpStatus.get());
+    }
+  }
+
+  @Override
+  protected AccessToken login(String url, HttpEntity entity, Consumer<Integer> httpStatusCallback) {
+    AccessToken token = new AccessToken("token");
+    Optional.ofNullable(httpStatusCallback).ifPresent((c) -> c.accept(200));
+    return new AccessToken("token");
+  }
+
+  // To fake it out, since we never call getResponseHandler()
+  @Override
+  public void init() throws CoreException {
+    LifecycleHelper.init(getResponseHandler());
+  }
+
+  public static class MyHttpClientBuilderConfigurator implements HttpClientBuilderConfigurator {
+    HttpClientBuilder mockBuilder;
+
+
+    MyHttpClientBuilderConfigurator(String responseContent, boolean hasError) throws Exception {
+      CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+      HttpEntity mockEntity = mock(HttpEntity.class);
+      when(response.getEntity()).thenReturn(mockEntity);
+      when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(responseContent, Charset.defaultCharset()));
+      when(response.getEntity().getContent()).thenReturn(IOUtils.toInputStream(responseContent,Charset.defaultCharset()));
+      CloseableHttpClient client = mock(CloseableHttpClient.class);
+      if (hasError) {
+        when(client.execute((HttpUriRequest) anyObject())).thenThrow(new IOException());
+        when(client.execute((HttpUriRequest) anyObject(), (ResponseHandler) anyObject())).thenThrow(new IOException());
+
+      } else {
+        when(client.execute((HttpUriRequest) anyObject())).thenReturn(response);
+        when(client.execute((HttpUriRequest) anyObject(), (ResponseHandler) anyObject()))
+            .thenReturn(responseContent);
+      }
+      mockBuilder = mock(HttpClientBuilder.class);
+      when(mockBuilder.build()).thenReturn(client);
+    }
+
+    @Override
+    public HttpClientBuilder configure(HttpClientBuilder builder) throws Exception {
+      return mockBuilder;
+    }
+
+  }
+
+
+}

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericOauthTokenTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/GenericOauthTokenTest.java
@@ -17,33 +17,15 @@
 package com.adaptris.core.oauth.generic;
 import static com.adaptris.core.oauth.generic.JsonResponseHandlerTest.ACCESS_TOKEN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpStatus;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicStatusLine;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
 import com.adaptris.core.http.oauth.GetOauthToken;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.core.oauth.generic.GenericAccessTokenImplTest.MyHttpClientBuilderConfigurator;
 import com.adaptris.core.util.LifecycleHelper;
 
 @SuppressWarnings("deprecation")
@@ -91,6 +73,8 @@ public class GenericOauthTokenTest extends ServiceCase {
       LifecycleHelper.initAndStart(service);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       msg.addMessageHeader("hello", "world");
+      msg.addMessageHeader("password", "MyPassword");
+      msg.addMessageHeader("client_id", "MyClientId");
       service.doService(msg);
       String bearerToken = "Bearer token";
       assertEquals(bearerToken, msg.getMetadataValue("Authorization"));
@@ -124,10 +108,10 @@ public class GenericOauthTokenTest extends ServiceCase {
   @Test
   public void testLogin_WithError() throws Exception {
     GetOauthToken service = new GetOauthToken();
-    service.setAccessTokenBuilder(new GenericAccessToken()
+    service
+        .setAccessTokenBuilder(new GenericAccessToken().withMetadataFilter(new NoOpMetadataFilter())
         .withResponseHandler(new JsonResponseHandler()).withTokenUrl("http://localhost:1234")
-        .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, true))
-        .withMetadataFilter(new NoOpMetadataFilter()));
+            .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, true)));
     try {
       LifecycleHelper.initAndStart(service);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
@@ -138,73 +122,5 @@ public class GenericOauthTokenTest extends ServiceCase {
     } finally {
       LifecycleHelper.stopAndClose(service);
     }
-  }
-
-
-  @Test
-  public void testCustomResponseHandler() throws Exception {
-    BasicStatusLine status = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK");
-    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-    HttpEntity mockEntity = mock(HttpEntity.class);
-    when(response.getEntity()).thenReturn(mockEntity);
-    when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(ACCESS_TOKEN));
-    when(response.getStatusLine()).thenReturn(status);
-
-
-    GenericAccessToken.CustomResponseHandler handler = new GenericAccessToken.CustomResponseHandler();
-    assertEquals(ACCESS_TOKEN, handler.handleResponse(response));
-    assertNotNull(handler.statusLine());
-    assertTrue(handler.statusLine().contains("HTTP/1.1"));
-    handler.throwExceptionIfAny();
-  }
-
-  @Test
-  public void testCustomResponseHandler_NotFound() throws Exception {
-    BasicStatusLine status = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_NOT_FOUND, "Not Found");
-    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-    HttpEntity mockEntity = mock(HttpEntity.class);
-    when(response.getEntity()).thenReturn(mockEntity);
-    when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(ACCESS_TOKEN));
-    when(response.getStatusLine()).thenReturn(status);
-    try {
-      GenericAccessToken.CustomResponseHandler handler = new GenericAccessToken.CustomResponseHandler();
-      assertEquals(ACCESS_TOKEN, handler.handleResponse(response));
-      assertNotNull(handler.statusLine());
-      assertTrue(handler.statusLine().contains("HTTP/1.1"));
-      handler.throwExceptionIfAny();
-      fail();
-    } catch (HttpResponseException expected) {
-
-    }
-  }
-
-  private class MyHttpClientBuilderConfigurator implements HttpClientBuilderConfigurator {
-    HttpClientBuilder mockBuilder;
-
-
-    MyHttpClientBuilderConfigurator(String responseContent, boolean hasError) throws Exception {
-      CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-      HttpEntity mockEntity = mock(HttpEntity.class);
-      when(response.getEntity()).thenReturn(mockEntity);
-      when(mockEntity.getContent()).thenReturn(IOUtils.toInputStream(responseContent, Charset.defaultCharset()));
-      when(response.getEntity().getContent()).thenReturn(IOUtils.toInputStream(responseContent,Charset.defaultCharset()));
-      CloseableHttpClient client = mock(CloseableHttpClient.class);
-      if (hasError) {
-        when(client.execute((HttpUriRequest) anyObject())).thenThrow(new IOException());
-        when(client.execute((HttpUriRequest) anyObject(), (ResponseHandler) anyObject())).thenThrow(new IOException());
-
-      } else {
-        when(client.execute((HttpUriRequest) anyObject())).thenReturn(response);
-        when(client.execute((HttpUriRequest) anyObject(), (ResponseHandler) anyObject())).thenReturn(responseContent);
-      }
-      mockBuilder = mock(HttpClientBuilder.class);
-      when(mockBuilder.build()).thenReturn(client);
-    }
-
-    @Override
-    public HttpClientBuilder configure(HttpClientBuilder builder) throws Exception {
-      return mockBuilder;
-    }
-
   }
 }

--- a/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/JsonBasedTokenTest.java
+++ b/interlok-oauth-generic/src/test/java/com/adaptris/core/oauth/generic/JsonBasedTokenTest.java
@@ -1,0 +1,61 @@
+/*
+    Copyright Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.oauth.generic;
+import static com.adaptris.core.oauth.generic.JsonResponseHandlerTest.ACCESS_TOKEN;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.http.oauth.GetOauthToken;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.oauth.generic.GenericAccessTokenImplTest.MyHttpClientBuilderConfigurator;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class JsonBasedTokenTest extends ExampleServiceCase {
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    GetOauthToken service = new GetOauthToken();
+    service.setAccessTokenBuilder(
+        new JsonBasedAccessToken().withResponseHandler(new JsonResponseHandler())
+            .withTokenUrl("http://my-oauth-server.com/oauth"));
+    return service;
+  }
+
+  @Test
+  public void testLogin() throws Exception {
+    GetOauthToken service = new GetOauthToken();
+    service.setAccessTokenBuilder(new JsonBasedAccessToken()
+        .withContentBuilder(new RegexMetadataFilter().withIncludePatterns("password"))
+        .withResponseHandler(new JsonResponseHandler())
+            .withTokenUrl("http://localhost:1234")
+            .withClientConfig(new MyHttpClientBuilderConfigurator(ACCESS_TOKEN, false)));
+    try {
+      LifecycleHelper.initAndStart(service);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      msg.addMessageHeader("hello", "world");
+      msg.addMessageHeader("password", "MyPassword");
+      msg.addMessageHeader("client_id", "MyClientId");
+      service.doService(msg);
+      String bearerToken = "Bearer token";
+      assertEquals(bearerToken, msg.getMetadataValue("Authorization"));
+    } finally {
+      LifecycleHelper.stopAndClose(service);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

The PR is two fold

### INTERLOk-3447

Currently the generic access token doesn't give you any indication of what the failure code was. Sometimes it's useful to "know what the HTTP response is". It's a possibility in a high-volume environment for you to exceed any arbitrary API limits and get a 427 "too many" response back. Since the exception is eaten, we have no idea of what the status code is.

### INTERLOK-3440

Some OAUTH tokens aren't form-based; they actually take a JSON payload along with some additional headers (in this instance `Accept` and `Stream-Nonce` are the additional headers.

```
POST https://www.demo.go2stream.net/api/oauth HTTP/1.1 
Accept: application/json 
Content-Type: application/json 
Stream-Nonce: 32f6888f-6bed-4d1f-89d4-2bfe2453852b 

{
    "grant_type": "client_credentials",
    "client_id": "XXXXXX",
    "client_secret": "SECRET"
}
```

## Modification

- Refactor to have a GenericAccessTokenImpl for use with INTERLOK-3440. 
    - This propagates the HTTP status back into the message.
    - An Exception is still thrown if the HTTP status is !=200 (so you need to use continue-on-fail)
- Deprecate GenericAccessToken in favour of FormBasedAccessToken
- Add a new JsonBasedAccessToken that turns metadata into a JSON object and does an HTTP post to retrieve the access token.
- GenericAccessTokenImpl supports a metadata filter to set additional headers.

## Result

If you're using `generic-oauth-access-token` then a warning will be logged on startup.
You can now configure a `oauth-access-token-via-form` or `oauth-access-token-via-json` as your token builders if you want to do OAUTH.

## Testing

```
<add-metadata-service>
  <metadata-element key="client_id" value="XXXX"/>
  <metadata-element key="client_secret" value="SECRET"/>
  <metadata-element key="grant_type" value="client_credentials"/>
</add-metadata-service>
 <get-oauth-token>
   <access-token-builder class="oauth-access-token-via-json">
    <token-url>http://my-oauth-server.com/oauth</token-url>
    <response-handler class="oauth-json-response"/>
    <content-builder class="regex-metadata-filter">
     <include-pattern>client_id</include-pattern>
     <include-pattern>client_secret</include-pattern>
     <include-pattern>grant_type</include-pattern>
    </content-builder>
   </access-token-builder>
  </get-oauth-token>
```
- Will now build a payload of `{"client_id":"XXX", "client_secret":"secret", "grant_type":"client_credentials"}`, post that to the URL and give you an AccessToken in metadata...
- The message should now contain `adphttpresponse` metadata (200 hopefully)
