### PR TITLE
updated use of dep reader input stream constructor

### DIFF
--- a/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/XmlResponseHandler.java
+++ b/interlok-oauth-generic/src/main/java/com/adaptris/core/oauth/generic/XmlResponseHandler.java
@@ -97,7 +97,7 @@ public class XmlResponseHandler extends ResponseHandlerImpl {
   @Override
   public AccessToken buildToken(String loginResponse) throws CoreException {
     XPath xpath = XPath.newXPathInstance(factoryBuilder, nsCtx);
-    try (ReaderInputStream in = new ReaderInputStream(new StringReader(loginResponse), Charset.defaultCharset())) {
+    try (ReaderInputStream in = ReaderInputStream.builder().setReader(new StringReader(loginResponse)).setCharset(Charset.defaultCharset()).get()) {
       Document xml = XmlHelper.createDocument(in, factoryBuilder);
 
       String accessToken = xpath.selectSingleTextItem(xml, getAccessTokenPath());


### PR DESCRIPTION
## Motivation

removing deprecated warning

## Modification

updated the use of the constructor ReaderInputStream(Reader, Charset)